### PR TITLE
Modify the output so that Jenkins XUnit plugin will parse it correctly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,3 @@ gem "nokogiri"
 gem "simplecov"
 gem "builder"
 gem "reek"
-

--- a/features/individual_suites.feature
+++ b/features/individual_suites.feature
@@ -76,4 +76,5 @@ Feature: Individual suites
     When I run `rspec spec/suite_one_spec.rb spec/suite_two_spec.rb -r ../../lib/yarjuf -f JUnit -o results.xml`
     Then the junit output file contains two testsuite elements named 'suite one' and 'suite two'
     And the junit output file has the correct test counts against each suite
-
+    When I run `rspec spec/suite_timestamp_spec.rb -r ../../lib/yarjuf -f JUnit -o results.xml`
+    Then the junit output testsuite element contains a timestamp of each suite

--- a/features/step_definitions/individual_suite_details_steps.rb
+++ b/features/step_definitions/individual_suite_details_steps.rb
@@ -22,3 +22,8 @@ Then /^the junit output file has the correct test counts against each suite$/ do
   @results.at_xpath("/testsuites/testsuite[@name='suite two']/@skipped").value.should == "2"
 end
 
+Then /^the junit output testsuite element contains a timestamp of each suite$/ do
+  step 'I parse the junit results file'
+  @results.at_xpath("/testsuites/testsuite[@name='suite one']/@timestamp").value.should match /\d{4}-\d{2}-\d{2}T\d+:\d+:\d+\+\d+:\d+/
+  @results.at_xpath("/testsuites/testsuite[@name='suite two']/@timestamp").value.should match /\d{4}-\d{2}-\d{2}T\d+:\d+:\d+\+\d+:\d+/
+end

--- a/features/step_definitions/suite_level_details_steps.rb
+++ b/features/step_definitions/suite_level_details_steps.rb
@@ -7,7 +7,6 @@ Then /^the junit output reports one passing test$/ do
   step 'I parse the junit results file'
   @results.at_xpath("/testsuites/@errors").value.should == "0"
   @results.at_xpath("/testsuites/@failures").value.should == "0"
-  @results.at_xpath("/testsuites/@skipped").value.should == "0"
   @results.at_xpath("/testsuites/@tests").value.should == "1"
 end
 
@@ -15,7 +14,6 @@ Then /^the junit output reports one failing test$/ do
   step 'I parse the junit results file'
   @results.at_xpath("/testsuites/@errors").value.should == "0"
   @results.at_xpath("/testsuites/@failures").value.should == "1"
-  @results.at_xpath("/testsuites/@skipped").value.should == "0"
   @results.at_xpath("/testsuites/@tests").value.should == "1"
 end
 
@@ -23,7 +21,6 @@ Then /^the junit output reports one pending test$/ do
   step 'I parse the junit results file'
   @results.at_xpath("/testsuites/@errors").value.should == "0"
   @results.at_xpath("/testsuites/@failures").value.should == "0"
-  @results.at_xpath("/testsuites/@skipped").value.should == "1"
   @results.at_xpath("/testsuites/@tests").value.should == "1"
 end
 
@@ -31,9 +28,3 @@ Then /^the junit output testsuite element contains a duration$/ do
   step 'I parse the junit results file'
   @results.at_xpath("/testsuites/@time").value.should match /[.0-9]+/
 end
-
-Then /^the junit output testsuite element contains a timestamp$/ do
-  step 'I parse the junit results file'
-  @results.at_xpath("/testsuites/@timestamp").value.should match /\d{4}-\d{2}-\d{2}T\d+:\d+:\d+\+\d+:\d+/
-end
-

--- a/features/suite_level_details.feature
+++ b/features/suite_level_details.feature
@@ -62,16 +62,3 @@ Feature: Suite Summary
       """
     When I run `rspec spec/suite_duration_spec.rb -r ../../lib/yarjuf -f JUnit -o results.xml`
     Then the junit output testsuite element contains a duration
-
-  Scenario: Test suite time stamp
-    Given a file named "spec/suite_timestamp_spec.rb" with:
-      """
-      describe "suite element timestamp" do
-        it "should contain a timestamp" do
-          1.should == 1
-        end
-      end
-      """
-    When I run `rspec spec/suite_timestamp_spec.rb -r ../../lib/yarjuf -f JUnit -o results.xml`
-    Then the junit output testsuite element contains a timestamp
-

--- a/lib/yarjuf.rb
+++ b/lib/yarjuf.rb
@@ -42,7 +42,7 @@ class JUnit < RSpec::Core::Formatters::BaseFormatter
     exception = example.metadata[:execution_result][:exception]
     exception.nil? ? "" : "#{exception.message}\n#{format_backtrace(exception.backtrace, example).join("\n")}"
   end
-  
+
   #utility methods
 
   def self.count_in_suite_of_type(suite, test_case_result_type)
@@ -67,7 +67,7 @@ class JUnit < RSpec::Core::Formatters::BaseFormatter
       build_all_suites
     end
   end
-  
+
   def build_all_suites
     @test_suite_results.each do |suite_name, tests|
       build_test_suite suite_name, tests
@@ -83,7 +83,7 @@ class JUnit < RSpec::Core::Formatters::BaseFormatter
       build_all_tests tests
     end
   end
-  
+
   def build_all_tests(tests)
     tests.each do |test|
       build_test test
@@ -94,7 +94,7 @@ class JUnit < RSpec::Core::Formatters::BaseFormatter
     test_name = test.metadata[:full_description]
     execution_time = test.metadata[:execution_result][:run_time]
     test_status = test.metadata[:execution_result][:status]
-    
+
     @builder.testcase :name => test_name, :time => execution_time do
       case test_status
       when "pending" then @builder.skipped
@@ -105,7 +105,7 @@ class JUnit < RSpec::Core::Formatters::BaseFormatter
 
   def build_failed_test(test)
     failure_message = "failed #{test.metadata[:full_description]}"
-    
+
     @builder.failure :message => failure_message, :type => "failed" do
       @builder.cdata! failure_details_for test
     end

--- a/lib/yarjuf.rb
+++ b/lib/yarjuf.rb
@@ -63,7 +63,7 @@ class JUnit < RSpec::Core::Formatters::BaseFormatter
 
   def build_results(duration, example_count, failure_count, pending_count)
     @builder.instruct! :xml, :version => "1.0", :encoding => "UTF-8"
-    @builder.testsuites :errors => 0, :failures => failure_count, :skipped => pending_count, :tests => example_count, :time => duration, :timestamp => Time.now.iso8601 do
+    @builder.testsuites :errors => 0, :failures => failure_count, :tests => example_count, :time => duration do
       build_all_suites
     end
   end
@@ -77,8 +77,8 @@ class JUnit < RSpec::Core::Formatters::BaseFormatter
   def build_test_suite(suite_name, tests)
     failure_count = JUnit.count_in_suite_of_type tests, "failed"
     skipped_count = JUnit.count_in_suite_of_type tests, "pending"
-        
-    @builder.testsuite :name => suite_name, :tests => tests.size, :errors => 0, :failures => failure_count, :skipped => skipped_count do
+
+    @builder.testsuite :name => suite_name, :tests => tests.size, :errors => 0, :failures => failure_count, :skipped => skipped_count, :timestamp => Time.now.iso8601 do
       @builder.properties
       build_all_tests tests
     end


### PR DESCRIPTION
It seems that xunit performs some validations on the output XML with test results.

BTW I've found this schema 
https://svn.jenkins-ci.org/trunk/hudson/dtkit/dtkit-format/dtkit-junit-model/src/main/resources/com/thalesgroup/dtkit/junit/model/xsd/junit-4.xsd
