### PR TITLE
Broken dependencies fix

### DIFF
--- a/yarjuf.gemspec
+++ b/yarjuf.gemspec
@@ -22,10 +22,9 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('builder')
 
   gem.add_development_dependency('nokogiri', '~> 1.5.10') # for Ruby 1.8.7
-  gem.add_development_dependency('rake')
-  gem.add_development_dependency('cucumber')
-  gem.add_development_dependency('aruba')
-  gem.add_development_dependency('simplecov')
+  gem.add_development_dependency('rake', '~> 10.3.2')
+  gem.add_development_dependency('cucumber', '~> 1.3.16')
+  gem.add_development_dependency('aruba', '~> 0.6.0')
   gem.add_development_dependency('simplecov', '~> 0.8.2') # for Ruby 1.8.7
   gem.add_development_dependency('reek', ['= 1.3.7']) # for Ruby 1.8.7
   gem.add_development_dependency('rainbow', '~> 1.99.2') # for Ruby 1.8.7

--- a/yarjuf.gemspec
+++ b/yarjuf.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('cucumber')
   gem.add_development_dependency('aruba')
   gem.add_development_dependency('simplecov')
+  gem.add_development_dependency('simplecov', '~> 0.8.2') # for Ruby 1.8.7
   gem.add_development_dependency('reek', ['= 1.3.7']) # for Ruby 1.8.7
   gem.add_development_dependency('rainbow', '~> 1.99.2') # for Ruby 1.8.7
 end


### PR DESCRIPTION
A new version of `simplecov` was released (`0.9`) which broke the build for Ruby `1.8.7`.

https://travis-ci.org/natritmeyer/yarjuf/jobs/31050477

``` bash
$ bundle exec rake
/home/travis/.rvm/rubies/ruby-1.8.7-p374/bin/ruby -I lib -S rspec spec/formatter_conformity_spec.rb
....
Finished in 0.00249 seconds
4 examples, 0 failures
/home/travis/.rvm/rubies/ruby-1.8.7-p374/bin/ruby -S bundle exec cucumber --format pretty
[WARNING] MultiJson is using the default adapter (ok_json).We recommend loading a different JSON library to improve performance.
undefined method `home' for Dir:Class (NoMethodError)
/home/travis/.rvm/gems/ruby-1.8.7-p374/gems/simplecov-0.9.0/lib/simplecov/defaults.rb:87
/home/travis/.rvm/gems/ruby-1.8.7-p374/gems/simplecov-0.9.0/lib/simplecov.rb:140:in `require'
/home/travis/.rvm/gems/ruby-1.8.7-p374/gems/simplecov-0.9.0/lib/simplecov.rb:140
/home/travis/build/natritmeyer/yarjuf/features/support/env.rb:1:in `require'
/home/travis/build/natritmeyer/yarjuf/features/support/env.rb:1
/home/travis/.rvm/gems/ruby-1.8.7-p374/gems/cucumber-1.3.16/bin/../lib/cucumber/rb_support/rb_language.rb:95:in `load'
/home/travis/.rvm/gems/ruby-1.8.7-p374/gems/cucumber-1.3.16/bin/../lib/cucumber/rb_support/rb_language.rb:95:in `load_code_file'
/home/travis/.rvm/gems/ruby-1.8.7-p374/gems/cucumber-1.3.16/bin/../lib/cucumber/runtime/support_code.rb:180:in `load_file'
/home/travis/.rvm/gems/ruby-1.8.7-p374/gems/cucumber-1.3.16/bin/../lib/cucumber/runtime/support_code.rb:83:in `load_files!'
/home/travis/.rvm/gems/ruby-1.8.7-p374/gems/cucumber-1.3.16/bin/../lib/cucumber/runtime/support_code.rb:82:in `each'
/home/travis/.rvm/gems/ruby-1.8.7-p374/gems/cucumber-1.3.16/bin/../lib/cucumber/runtime/support_code.rb:82:in `load_files!'
/home/travis/.rvm/gems/ruby-1.8.7-p374/gems/cucumber-1.3.16/bin/../lib/cucumber/runtime.rb:184:in `load_step_definitions'
/home/travis/.rvm/gems/ruby-1.8.7-p374/gems/cucumber-1.3.16/bin/../lib/cucumber/runtime.rb:42:in `run!'
/home/travis/.rvm/gems/ruby-1.8.7-p374/gems/cucumber-1.3.16/bin/../lib/cucumber/cli/main.rb:47:in `execute!'
/home/travis/.rvm/gems/ruby-1.8.7-p374/gems/cucumber-1.3.16/bin/cucumber:13
/home/travis/.rvm/gems/ruby-1.8.7-p374/bin/cucumber:23:in `load'
/home/travis/.rvm/gems/ruby-1.8.7-p374/bin/cucumber:23
The command "bundle exec rake" exited with 1.
```

This change locks down the `gemspec` to the previous working version of `simplecov` whilst also locking down `rake`, `cucumber` and `aruba` just in case.
