### PR TITLE
Updated .rvmrc to not be locked on specific patch level. Use latest 1.9

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,2 +1,2 @@
-rvm --create ruby-1.9.3-p194@yarjuf
+rvm --create ruby-1.9.3@yarjuf
 


### PR DESCRIPTION
Just a small NIT, noticed this and that patch level doesn't even compile on 10.10.
