### PR TITLE
Add seed to output if using random order

### DIFF
--- a/features/step_definitions/suite_level_details_steps.rb
+++ b/features/step_definitions/suite_level_details_steps.rb
@@ -37,3 +37,8 @@ Then /^the junit output testsuite element contains a timestamp$/ do
   expect(@results.at_xpath("/testsuites/@timestamp").value).to match /\d{4}-\d{2}-\d{2}T\d+:\d+:\d+\+\d+:\d+/
 end
 
+Then /^the junit output testsuite element contains a seed$/ do
+  step 'I parse the junit results file'
+  expect(@results.at_xpath("/testsuites/@seed").value).to match /\d+/
+end
+

--- a/features/suite_level_details.feature
+++ b/features/suite_level_details.feature
@@ -76,3 +76,15 @@ Feature: Suite Summary
     When I run `rspec spec/suite_timestamp_spec.rb -r ../../lib/yarjuf -f JUnit -o results.xml`
     Then the junit output testsuite element contains a timestamp
 
+  Scenario: Test suite seed present if seed is used
+    Given a file named "spec/suite_seed_spec.rb" with:
+      """
+      describe "suite element seed" do
+        it "should contain a seed" do
+          expect(1).to eq 1
+        end
+      end
+      """
+    When I run `rspec spec/suite_seed_spec.rb -r ../../lib/yarjuf -f JUnit -o results.xml --order random`
+    Then the junit output testsuite element contains a seed
+

--- a/lib/yarjuf/j_unit.rb
+++ b/lib/yarjuf/j_unit.rb
@@ -1,6 +1,8 @@
+require "nokogiri"
+
 # An RSpec formatter for generating results in JUnit format
 class JUnit
-  RSpec::Core::Formatters.register self, :example_passed, :example_failed, :example_pending, :dump_summary
+  RSpec::Core::Formatters.register self, :example_passed, :example_failed, :example_pending, :dump_summary, :seed
 
   def initialize(output)
     @output             = output
@@ -22,7 +24,18 @@ class JUnit
 
   def dump_summary(summary)
     build_results(summary.duration, summary.examples.size, summary.failed_examples.size, summary.pending_examples.size)
-    @output.puts @builder.target!
+  end
+
+  def seed(seed_notification)
+    xml_output = @builder.target!
+
+    if seed_notification.seed_used?
+      doc = Nokogiri::XML xml_output
+      doc.root && doc.root["seed"] = seed_notification.seed
+      xml_output = doc.to_xml
+    end
+
+    @output.puts xml_output
   end
 
   protected


### PR DESCRIPTION
This adds a `seed` attribute to the `testsuites` root node if using a random spec order, so the order can be reconstructed (to catch order-dependent specs).
