### PR TITLE
Nil-check exception backtrace before passing it to RSpec

### DIFF
--- a/features/individual_tests.feature
+++ b/features/individual_tests.feature
@@ -72,3 +72,16 @@ Feature: Individual Tests
     When I run `rspec spec/failing_test_spec.rb -r ../../lib/yarjuf -f JUnit -o results.xml`
     Then the junit output file contains a failing test
 
+  Scenario: Failing test with nil backtrace
+    Given a file named "spec/failing_test_spec.rb" with:
+      """
+      describe "suite one" do
+        it "raises an exception" do
+          class E < Exception; def backtrace; nil; end; end
+          raise E.new('Test exception')
+        end
+      end
+      """
+    When I run `rspec spec/failing_test_spec.rb -r ../../lib/yarjuf -f JUnit -o results.xml`
+    Then the junit output file contains a failing test with the exception message
+

--- a/features/step_definitions/individual_tests_steps.rb
+++ b/features/step_definitions/individual_tests_steps.rb
@@ -26,3 +26,11 @@ Then /^the junit output file contains a failing test$/ do
   expect(@results.at_xpath("/testsuites/testsuite/testcase/failure").text).to match /expected.*2.*got.*1.*using.*==.*spec\/failing_test_spec\.rb:3/m
 end
 
+Then /^the junit output file contains a failing test with the exception message$/ do
+  step 'I parse the junit results file'
+  expect(@results.at_xpath("/testsuites/testsuite/testcase/failure")).to_not be_nil
+  expect(@results.at_xpath("/testsuites/testsuite/testcase/failure/@message").value).to eq "failed suite one raises an exception"
+  expect(@results.at_xpath("/testsuites/testsuite/testcase/failure/@type").value).to eq "failed"
+  expect(@results.at_xpath("/testsuites/testsuite/testcase/failure").text).to match /Test exception/m
+end
+

--- a/features/step_definitions/suite_level_details_steps.rb
+++ b/features/step_definitions/suite_level_details_steps.rb
@@ -34,6 +34,6 @@ end
 
 Then /^the junit output testsuite element contains a timestamp$/ do
   step 'I parse the junit results file'
-  expect(@results.at_xpath("/testsuites/@timestamp").value).to match /\d{4}-\d{2}-\d{2}T\d+:\d+:\d+\+\d+:\d+/
+  expect(@results.at_xpath("/testsuites/@timestamp").value).to match /\d{4}-\d{2}-\d{2}T\d+:\d+:\d+(\+|\-)\d+:\d+/
 end
 

--- a/lib/yarjuf/j_unit.rb
+++ b/lib/yarjuf/j_unit.rb
@@ -35,7 +35,7 @@ class JUnit
 
   def failure_details_for(example)
     exception           = example.exception
-    formatted_backtrace = RSpec::Core::BacktraceFormatter.new.format_backtrace exception.backtrace
+    formatted_backtrace = exception.backtrace ? RSpec::Core::BacktraceFormatter.new.format_backtrace(exception.backtrace) : ""
     exception.nil? ? '' : "#{exception.message}\n#{formatted_backtrace}"
   end
 


### PR DESCRIPTION
When yarjuf is passed an exception with a `nil` backtrace, it would hand it off the RSpec's backtrace formatter unchecked which would cause RSpec to raise a NoMethodError when calling [`empty?`](https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/backtrace_formatter.rb#L34).

This PR will set `formatted_backtrace` to an empty string if `nil`, instead of passing to the RSpec backtrace formatter.

In addition, I changed the regex on the timestamp step definition to accept "+" or "-" on the UTC offset. It was failing for me since I am in CST.
